### PR TITLE
Add playlist/download manager, on-device status, and song-only export

### DIFF
--- a/PR_NOTES_WAVE_PLAYLIST_DOWNLOAD_MANAGER.md
+++ b/PR_NOTES_WAVE_PLAYLIST_DOWNLOAD_MANAGER.md
@@ -1,0 +1,166 @@
+# Pull Request: Playlist / Download Manager, Global On-Device Status, and Downloads Export
+
+## Summary
+
+This PR improves WAVE's offline/download and playlist management workflow.
+
+It adds a proper download/playlist management layer so downloaded songs are easier to organise, bulk add to playlists, remove from playlists, export for backup, and identify across the app.
+
+## Main changes
+
+### 1. Download / Playlist Manager
+
+Added a management workflow in `Library > Downloads` with KPI cards:
+
+- Downloaded
+- Not in playlist
+- In playlists
+- Playlists
+
+The KPI cards act as filters, making it easier to find downloaded tracks that still need to be organised.
+
+### 2. Multi-select for downloads
+
+Downloaded tracks can now be selected in bulk using:
+
+- long press on mobile
+- checkboxes
+- select visible
+- clear selection
+
+Bulk actions include:
+
+- add selected tracks to an existing playlist
+- create a new playlist from selected tracks
+
+### 3. Playlist management improvements
+
+Inside playlists, users can now better manage tracks, including:
+
+- adding downloaded tracks into a playlist
+- removing tracks from a playlist
+- keeping downloaded tracks separate from playlist membership
+
+This makes playlists easier to maintain after songs have already been downloaded.
+
+### 4. Global "On device" status
+
+Downloaded tracks now carry an "On device" status across more of the app, instead of only showing in some places.
+
+This applies across areas such as:
+
+- search results
+- home/content cards
+- album track lists
+- artist popular tracks
+- playlist track lists
+- now playing
+- detail rows
+
+The goal is that if a song is already downloaded, the app shows that status consistently wherever the song appears.
+
+### 5. Smarter download behaviour
+
+Download actions now avoid re-downloading songs that are already on the device.
+
+For albums/playlists/artist popular tracks:
+
+- if all tracks are already downloaded, the app shows that they are already on device
+- if only some tracks are missing, only the missing tracks are queued for download
+
+This prevents duplicate downloads and makes offline management clearer.
+
+### 6. Restore cloud-check delete behaviour
+
+The existing user behaviour is preserved:
+
+- cloud download icon = download the song
+- cloud check icon = remove/delete the downloaded song from device
+
+This keeps the download toggle simple and predictable.
+
+### 7. Android downloads backup export
+
+On Android, WAVE stores playable offline songs in app-private storage.
+
+Instead of showing the internal private path like:
+
+```text
+/data/user/0/com.example.wave/app_flutter/WAVE_Downloads
+```
+
+the app now explains that downloads are kept privately for playback and provides an export option.
+
+Export backup copies song files to:
+
+```text
+Internal storage/Download/WAVE/wave_downloads
+```
+
+The export is a backup/copy. WAVE still plays from its private app folder.
+
+### 8. Song-only backup export
+
+The export backup now copies only song/audio files.
+
+It skips:
+
+- cover artwork
+- `_cover` files
+- `.jpg`
+- `.jpeg`
+- `.png`
+- `.webp`
+- `.gif`
+- `wave_downloads_manifest.json`
+
+This keeps the exported backup folder clean and focused on the actual songs.
+
+### 9. Desktop behaviour preserved
+
+On Windows/macOS/Linux, the app continues to show the normal local download folder and lets the user open it.
+
+The Android-specific export messaging is only shown on Android.
+
+## Files changed
+
+```text
+lib/core/storage/library_providers.dart
+lib/features/library/library_screen.dart
+lib/widgets/player/add_to_playlist_sheet.dart
+lib/core/downloads/download_manager.dart
+android/app/src/main/AndroidManifest.xml
+lib/core/downloads/download_status.dart
+lib/widgets/on_device_badge.dart
+lib/widgets/content_cards.dart
+lib/widgets/detail_track_row.dart
+lib/features/album/album_screen.dart
+lib/features/artist/artist_screen.dart
+lib/features/playlist/playlist_screen.dart
+lib/features/player/now_playing_screen.dart
+```
+
+## Manual testing checklist
+
+Tested locally with the following flows:
+
+- Open `Library > Downloads`
+- KPI cards display correctly
+- Filter by downloaded tracks
+- Filter by tracks not in a playlist
+- Multi-select downloaded tracks
+- Add selected tracks to an existing playlist
+- Create a new playlist from selected tracks
+- Open a playlist and remove songs
+- Open downloads and verify selected tracks can be managed
+- Verify downloaded tracks show `On device` across multiple screens
+- Verify already downloaded tracks are not re-downloaded
+- Verify cloud-check removes/deletes the downloaded song from device
+- Verify Android export backup copies song files only
+- Verify desktop still shows the normal download folder
+
+## Notes
+
+This PR focuses on local/offline management and does not add cloud sync.
+
+The Android export is intended as a backup/copy of downloaded audio files, not as the active playback location.

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK"/>
+    <!-- Best-effort legacy support for exporting backups to public Downloads on older Android versions. -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
 
     <!-- OTA Update Permissions -->
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />

--- a/lib/core/downloads/download_manager.dart
+++ b/lib/core/downloads/download_manager.dart
@@ -35,6 +35,36 @@ final downloadLocationProvider = FutureProvider<String>((ref) async {
   return ref.read(downloadManagerProvider).downloadsDirectory();
 });
 
+class DownloadExportTarget {
+  const DownloadExportTarget({
+    required this.privatePath,
+    required this.exportPath,
+    required this.label,
+    required this.isPublicBackup,
+  });
+
+  final String privatePath;
+  final String exportPath;
+  final String label;
+  final bool isPublicBackup;
+}
+
+class DownloadExportResult {
+  const DownloadExportResult({
+    required this.privatePath,
+    required this.exportPath,
+    required this.filesCopied,
+    required this.bytesCopied,
+    required this.metadataItems,
+  });
+
+  final String privatePath;
+  final String exportPath;
+  final int filesCopied;
+  final int bytesCopied;
+  final int metadataItems;
+}
+
 class ActiveDownloadsNotifier extends Notifier<Map<int, double>> {
   @override
   Map<int, double> build() => {};
@@ -268,6 +298,140 @@ class DownloadManager {
 
   Future<String> downloadsDirectory() => _getAppDir();
 
+  Future<DownloadExportTarget> downloadExportTarget() async {
+    final privatePath = await _getAppDir();
+    final exportPath = await _defaultExportDir();
+
+    return DownloadExportTarget(
+      privatePath: privatePath,
+      exportPath: exportPath,
+      label: _exportLabelForPath(exportPath),
+      isPublicBackup: exportPath != privatePath,
+    );
+  }
+
+  Future<String> _defaultExportDir({String? parentDirectory}) async {
+    if (parentDirectory != null && parentDirectory.trim().isNotEmpty) {
+      return p.join(parentDirectory, 'WAVE', 'wave_downloads');
+    }
+
+    if (Platform.isAndroid) {
+      // Best-effort user-visible Android backup path.
+      // WAVE still keeps its playable offline files inside app-private storage.
+      return p.join(
+        '/storage/emulated/0',
+        'Download',
+        'WAVE',
+        'wave_downloads',
+      );
+    }
+
+    if (Platform.isWindows || Platform.isMacOS || Platform.isLinux) {
+      try {
+        final downloads = await getDownloadsDirectory();
+        if (downloads != null) {
+          return p.join(downloads.path, 'WAVE', 'wave_downloads');
+        }
+      } catch (_) {
+        // Fall back below.
+      }
+    }
+
+    final docs = await getApplicationDocumentsDirectory();
+    return p.join(docs.path, 'WAVE', 'wave_downloads');
+  }
+
+  String _exportLabelForPath(String path) {
+    if (Platform.isAndroid &&
+        path.replaceAll('\\', '/').contains('/Download/WAVE/wave_downloads')) {
+      return 'Internal storage/Download/WAVE/wave_downloads';
+    }
+    return path;
+  }
+
+  Future<DownloadExportResult> exportDownloadsBackup({
+    String? parentDirectory,
+  }) async {
+    final privatePath = await _getAppDir();
+    final exportPath = await _defaultExportDir(parentDirectory: parentDirectory);
+
+    final sourceDir = Directory(privatePath);
+    if (!await sourceDir.exists()) {
+      throw Exception('WAVE private download folder was not found.');
+    }
+
+    final destDir = Directory(exportPath);
+    if (!await destDir.exists()) {
+      await destDir.create(recursive: true);
+    }
+
+    var filesCopied = 0;
+    var bytesCopied = 0;
+
+    await for (final entity in sourceDir.list(recursive: false)) {
+      if (entity is! File) continue;
+
+      final name = p.basename(entity.path);
+      final lowerName = name.toLowerCase();
+      final ext = p.extension(lowerName);
+
+      if (name.endsWith('.part') || name.contains('.part.seg')) {
+        continue;
+      }
+
+      // Export backup is for songs only. Do not copy downloaded cover artwork
+      // or any extra metadata files into the user's public backup folder.
+      if (lowerName.contains('_cover') ||
+          ext == '.jpg' ||
+          ext == '.jpeg' ||
+          ext == '.png' ||
+          ext == '.webp' ||
+          ext == '.gif' ||
+          lowerName == 'wave_downloads_manifest.json') {
+        continue;
+      }
+
+      final target = File(p.join(destDir.path, name));
+      await target.parent.create(recursive: true);
+      await entity.copy(target.path);
+
+      filesCopied++;
+      bytesCopied += await target.length();
+    }
+
+    appLogger.i(
+      'Exported WAVE song backup to $exportPath '
+      '($filesCopied audio files, $bytesCopied bytes)',
+    );
+
+    return DownloadExportResult(
+      privatePath: privatePath,
+      exportPath: exportPath,
+      filesCopied: filesCopied,
+      bytesCopied: bytesCopied,
+      metadataItems: 0,
+    );
+  }
+
+  Future<void> openExportedDownloadsFolder({String? parentDirectory}) async {
+    final dir = await _defaultExportDir(parentDirectory: parentDirectory);
+
+    if (Platform.isWindows) {
+      await Process.run('explorer.exe', <String>[dir]);
+      return;
+    }
+    if (Platform.isMacOS) {
+      await Process.run('open', <String>[dir]);
+      return;
+    }
+    if (Platform.isLinux) {
+      await Process.run('xdg-open', <String>[dir]);
+      return;
+    }
+
+    throw UnsupportedError(_exportLabelForPath(dir));
+  }
+
   String? localAudioPathFor(int trackId) {
     final data = _box.get(trackId);
     if (data is! Map) return null;
@@ -306,8 +470,9 @@ class DownloadManager {
       return;
     }
 
+    final target = await downloadExportTarget();
     throw UnsupportedError(
-      'On Android, WAVE downloads are stored in app-private storage: $dir',
+      'WAVE stores playable downloads privately. Use Export backup to copy them to ${target.label}.',
     );
   }
 

--- a/lib/core/downloads/download_status.dart
+++ b/lib/core/downloads/download_status.dart
@@ -1,0 +1,77 @@
+import '../api/models/deezer_track.dart';
+import 'local_download_matcher.dart';
+
+class DownloadCoverage {
+  const DownloadCoverage({
+    required this.total,
+    required this.onDevice,
+    required this.missingTracks,
+  });
+
+  final int total;
+  final int onDevice;
+  final List<DeezerTrack> missingTracks;
+
+  int get missing => missingTracks.length;
+  bool get hasTracks => total > 0;
+  bool get allOnDevice => hasTracks && missing == 0;
+  bool get noneOnDevice => hasTracks && onDevice == 0;
+  bool get partiallyOnDevice => hasTracks && onDevice > 0 && missing > 0;
+}
+
+bool isTrackOnDevice(
+  DeezerTrack track,
+  List<DeezerTrack> downloadedTracks,
+) {
+  return LocalDownloadMatcher.findDownloadedMatchInList(
+        track,
+        downloadedTracks,
+      ) !=
+      null;
+}
+
+List<DeezerTrack> tracksMissingFromDevice(
+  List<DeezerTrack> tracks,
+  List<DeezerTrack> downloadedTracks,
+) {
+  final missing = <DeezerTrack>[];
+  final seen = <int>{};
+
+  for (final track in tracks) {
+    if (!seen.add(track.id)) continue;
+    if (!isTrackOnDevice(track, downloadedTracks)) {
+      missing.add(track);
+    }
+  }
+
+  return missing;
+}
+
+DownloadCoverage downloadCoverageForTracks(
+  List<DeezerTrack> tracks,
+  List<DeezerTrack> downloadedTracks,
+) {
+  final unique = <int, DeezerTrack>{};
+  for (final track in tracks) {
+    unique[track.id] = track;
+  }
+
+  if (unique.isEmpty) {
+    return const DownloadCoverage(
+      total: 0,
+      onDevice: 0,
+      missingTracks: <DeezerTrack>[],
+    );
+  }
+
+  final missing = tracksMissingFromDevice(
+    unique.values.toList(growable: false),
+    downloadedTracks,
+  );
+
+  return DownloadCoverage(
+    total: unique.length,
+    onDevice: unique.length - missing.length,
+    missingTracks: missing,
+  );
+}

--- a/lib/core/storage/library_providers.dart
+++ b/lib/core/storage/library_providers.dart
@@ -297,35 +297,41 @@ class LocalPlaylistTracksNotifier extends Notifier<Map<int, List<DeezerTrack>>> 
   }
 
   Future<void> addTrack(int playlistId, DeezerTrack track) async {
-    final currentList = state[playlistId] ?? <DeezerTrack>[];
-    if (currentList.any((t) => t.id == track.id)) {
-      return;
-    }
+    await addTracks(playlistId, <DeezerTrack>[track]);
+  }
 
-    final newList = <DeezerTrack>[...currentList, track];
+  Future<void> addTracks(int playlistId, List<DeezerTrack> tracks) async {
+    if (tracks.isEmpty) return;
+
+    final currentList = state[playlistId] ?? <DeezerTrack>[];
+    final existingIds = currentList.map((t) => t.id).toSet();
+    final toAdd = tracks
+        .where((track) => !existingIds.contains(track.id))
+        .toList(growable: false);
+
+    if (toAdd.isEmpty) return;
+
+    final newList = <DeezerTrack>[...currentList, ...toAdd];
 
     state = <int, List<DeezerTrack>>{
       ...state,
       playlistId: newList,
     };
 
-    final tracksBox = Hive.box<dynamic>(HiveBoxes.playlistTracks);
-    await tracksBox.put(
-      playlistId.toString(),
-      newList.map((t) => _deepJson(t.toJson())).toList(),
-    );
-
-    await _writePlaylistMetadata(playlistId, newList);
-
-    // playlistProvider(id) watches userPlaylistsProvider for local playlists,
-    // so this refreshes open local playlist headers and list screens.
-    ref.invalidate(userPlaylistsProvider);
+    await _persistPlaylistTracks(playlistId, newList);
   }
 
   Future<void> removeTrack(int playlistId, int trackId) async {
+    await removeTracks(playlistId, <int>[trackId]);
+  }
+
+  Future<void> removeTracks(int playlistId, Iterable<int> trackIds) async {
+    final ids = trackIds.toSet();
+    if (ids.isEmpty) return;
+
     final currentList = state[playlistId] ?? <DeezerTrack>[];
     final newList = currentList
-        .where((t) => t.id != trackId)
+        .where((t) => !ids.contains(t.id))
         .toList(growable: false);
 
     state = <int, List<DeezerTrack>>{
@@ -333,13 +339,20 @@ class LocalPlaylistTracksNotifier extends Notifier<Map<int, List<DeezerTrack>>> 
       playlistId: newList,
     };
 
+    await _persistPlaylistTracks(playlistId, newList);
+  }
+
+  Future<void> _persistPlaylistTracks(
+    int playlistId,
+    List<DeezerTrack> tracks,
+  ) async {
     final tracksBox = Hive.box<dynamic>(HiveBoxes.playlistTracks);
     await tracksBox.put(
       playlistId.toString(),
-      newList.map((t) => _deepJson(t.toJson())).toList(),
+      tracks.map((t) => _deepJson(t.toJson())).toList(),
     );
 
-    await _writePlaylistMetadata(playlistId, newList);
+    await _writePlaylistMetadata(playlistId, tracks);
 
     // playlistProvider(id) watches userPlaylistsProvider for local playlists,
     // so this refreshes open local playlist headers and list screens.

--- a/lib/features/album/album_screen.dart
+++ b/lib/features/album/album_screen.dart
@@ -9,6 +9,8 @@ import '../../core/api/models/deezer_album.dart';
 import '../../core/api/models/deezer_track.dart';
 import '../../core/audio/player_providers.dart';
 import '../../core/downloads/download_manager.dart';
+import '../../core/downloads/download_providers.dart';
+import '../../core/downloads/download_status.dart';
 import '../../core/router/app_router.dart';
 import '../../core/storage/library_providers.dart';
 import '../../core/theme/app_theme.dart';
@@ -68,6 +70,16 @@ class _AlbumBody extends ConsumerWidget {
     final theme = AppThemeScope.of(context);
     final saved =
         ref.watch(likedAlbumsProvider).any((a) => a.id == album.id);
+    final downloadableTracks = tracksAsync.maybeWhen(
+      data: (t) => t
+          .map((track) => track.album == null ? track.copyWith(album: album) : track)
+          .toList(growable: false),
+      orElse: () => const <DeezerTrack>[],
+    );
+    final albumCoverage = downloadCoverageForTracks(
+      downloadableTracks,
+      ref.watch(downloadedTracksProvider),
+    );
     final cover = album.coverXl ??
         album.coverBig ??
         album.coverMedium ??
@@ -203,22 +215,28 @@ class _AlbumBody extends ConsumerWidget {
                     GestureDetector(
                       behavior: HitTestBehavior.opaque,
                       onTap: () {
-                        final tracks = tracksAsync.maybeWhen(
-                          data: (t) => t
-                              .map((track) => track.album == null
-                                  ? track.copyWith(album: album)
-                                  : track)
-                              .toList(growable: false),
-                          orElse: () => const <DeezerTrack>[],
-                        );
-                        if (tracks.isEmpty) return;
-                        ref
-                            .read(downloadManagerProvider)
-                            .downloadAlbum(album.title, tracks);
+                        if (!albumCoverage.hasTracks) return;
+                        if (albumCoverage.allOnDevice) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(
+                              content: Text('Album is already on device: ${album.title}'),
+                            ),
+                          );
+                          return;
+                        }
+                        ref.read(downloadManagerProvider).queueTracks(
+                              albumCoverage.missingTracks,
+                              title: albumCoverage.partiallyOnDevice
+                                  ? 'Missing album tracks: ${album.title}'
+                                  : 'Album: ${album.title}',
+                              replaceFinishedQueue: false,
+                            );
                         ScaffoldMessenger.of(context).showSnackBar(
                           SnackBar(
                             content: Text(
-                              'Queued album download: ${album.title}',
+                              albumCoverage.partiallyOnDevice
+                                  ? 'Queued ${albumCoverage.missing} missing album tracks: ${album.title}'
+                                  : 'Queued album download: ${album.title}',
                             ),
                           ),
                         );
@@ -230,12 +248,18 @@ class _AlbumBody extends ConsumerWidget {
                           borderRadius: BorderRadius.circular(
                               theme.cardRadius == 0 ? 0 : 999),
                           border: Border.all(
-                            color: theme.onSurface.withValues(alpha: 0.2),
+                            color: albumCoverage.allOnDevice
+                                ? theme.accent
+                                : theme.onSurface.withValues(alpha: 0.2),
                           ),
                         ),
                         child: Icon(
-                          PhosphorIconsRegular.cloudArrowDown,
-                          color: theme.onSurface,
+                          albumCoverage.allOnDevice
+                              ? PhosphorIconsFill.cloudCheck
+                              : PhosphorIconsRegular.cloudArrowDown,
+                          color: albumCoverage.allOnDevice
+                              ? theme.accent
+                              : theme.onSurface,
                           size: 16,
                         ),
                       ),

--- a/lib/features/artist/artist_screen.dart
+++ b/lib/features/artist/artist_screen.dart
@@ -9,6 +9,8 @@ import '../../core/api/models/deezer_artist.dart';
 import '../../core/api/models/deezer_track.dart';
 import '../../core/audio/player_providers.dart';
 import '../../core/downloads/download_manager.dart';
+import '../../core/downloads/download_providers.dart';
+import '../../core/downloads/download_status.dart';
 import '../../core/storage/library_providers.dart';
 import '../../core/theme/app_theme.dart';
 import '../../widgets/content_cards.dart';
@@ -343,6 +345,14 @@ class _ActionRow extends ConsumerWidget {
     final following =
         ref.watch(followedArtistsProvider).any((a) => a.id == artist.id);
     final topAsync = ref.watch(artistTopTracksProvider(artist.id));
+    final popularTracks = topAsync.maybeWhen(
+      data: (t) => t.take(10).toList(growable: false),
+      orElse: () => const <DeezerTrack>[],
+    );
+    final popularCoverage = downloadCoverageForTracks(
+      popularTracks,
+      ref.watch(downloadedTracksProvider),
+    );
     return Row(
       children: <Widget>[
         Expanded(
@@ -372,11 +382,7 @@ class _ActionRow extends ConsumerWidget {
         GestureDetector(
           behavior: HitTestBehavior.opaque,
           onTap: () {
-            final tracks = topAsync.maybeWhen(
-              data: (t) => t.take(10).toList(growable: false),
-              orElse: () => const <DeezerTrack>[],
-            );
-            if (tracks.isEmpty) {
+            if (!popularCoverage.hasTracks) {
               ScaffoldMessenger.of(context).showSnackBar(
                 const SnackBar(
                   content: Text('Popular tracks are still loading'),
@@ -384,19 +390,29 @@ class _ActionRow extends ConsumerWidget {
               );
               return;
             }
+            if (popularCoverage.allOnDevice) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('Popular tracks are already on device: ${artist.name}'),
+                ),
+              );
+              return;
+            }
 
-            ref
-                .read(downloadManagerProvider)
-                .queueTracks(
-                  tracks,
-                  title: 'Popular: ${artist.name}',
+            ref.read(downloadManagerProvider).queueTracks(
+                  popularCoverage.missingTracks,
+                  title: popularCoverage.partiallyOnDevice
+                      ? 'Missing popular tracks: ${artist.name}'
+                      : 'Popular: ${artist.name}',
                   replaceFinishedQueue: false,
                 );
 
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: Text(
-                  'Queued popular tracks: ${artist.name}',
+                  popularCoverage.partiallyOnDevice
+                      ? 'Queued ${popularCoverage.missing} missing popular tracks: ${artist.name}'
+                      : 'Queued popular tracks: ${artist.name}',
                 ),
               ),
             );
@@ -408,12 +424,16 @@ class _ActionRow extends ConsumerWidget {
               borderRadius: BorderRadius.circular(
                   theme.cardRadius == 0 ? 0 : 999),
               border: Border.all(
-                color: theme.onSurface.withValues(alpha: 0.2),
+                color: popularCoverage.allOnDevice
+                    ? theme.accent
+                    : theme.onSurface.withValues(alpha: 0.2),
               ),
             ),
             child: Icon(
-              PhosphorIconsRegular.cloudArrowDown,
-              color: theme.onSurface,
+              popularCoverage.allOnDevice
+                  ? PhosphorIconsFill.cloudCheck
+                  : PhosphorIconsRegular.cloudArrowDown,
+              color: popularCoverage.allOnDevice ? theme.accent : theme.onSurface,
               size: 16,
             ),
           ),

--- a/lib/features/library/library_screen.dart
+++ b/lib/features/library/library_screen.dart
@@ -950,6 +950,8 @@ class _FollowingTab extends ConsumerWidget {
 // ---------------------------------------------------------------------------
 // Downloads ---------------------------------------------------------------
 
+enum _DownloadFilter { all, notInPlaylist, inPlaylist }
+
 class _DownloadsTab extends ConsumerStatefulWidget {
   const _DownloadsTab();
 
@@ -960,6 +962,8 @@ class _DownloadsTab extends ConsumerStatefulWidget {
 class _DownloadsTabState extends ConsumerState<_DownloadsTab> {
   late final TextEditingController _searchCtrl = TextEditingController();
   String _query = '';
+  _DownloadFilter _filter = _DownloadFilter.all;
+  final Set<int> _selectedIds = <int>{};
 
   @override
   void dispose() {
@@ -967,11 +971,75 @@ class _DownloadsTabState extends ConsumerState<_DownloadsTab> {
     super.dispose();
   }
 
+  bool get _selectionMode => _selectedIds.isNotEmpty;
+
+  void _setFilter(_DownloadFilter filter) {
+    setState(() {
+      _filter = filter;
+      _selectedIds.clear();
+    });
+  }
+
+  void _toggleSelected(int trackId) {
+    setState(() {
+      if (_selectedIds.contains(trackId)) {
+        _selectedIds.remove(trackId);
+      } else {
+        _selectedIds.add(trackId);
+      }
+    });
+  }
+
+  void _enterSelection(int trackId) {
+    setState(() {
+      _selectedIds.add(trackId);
+    });
+  }
+
+  void _selectAllVisible(List<DeezerTrack> visible) {
+    setState(() {
+      _selectedIds
+        ..clear()
+        ..addAll(visible.map((track) => track.id));
+    });
+  }
+
+  void _clearSelection() {
+    setState(() => _selectedIds.clear());
+  }
+
+  void _openBulkAddSheet(List<DeezerTrack> downloaded) {
+    final selectedTracks = downloaded
+        .where((track) => _selectedIds.contains(track.id))
+        .toList(growable: false);
+
+    if (selectedTracks.isEmpty) return;
+
+    showAddTracksToPlaylistSheet(context, selectedTracks);
+  }
+
   @override
   Widget build(BuildContext context) {
     final downloaded = ref.watch(downloadedTracksProvider);
     final queue = ref.watch(downloadQueueProvider);
-    final filtered = _filterDownloadedTracks(downloaded, _query);
+    final tracksByPlaylist = ref.watch(localPlaylistTracksProvider);
+    final playlistTrackIds = _downloadPlaylistTrackIds(tracksByPlaylist);
+    final notInPlaylist = downloaded
+        .where((track) => !playlistTrackIds.contains(track.id))
+        .toList(growable: false);
+    final inPlaylist = downloaded
+        .where((track) => playlistTrackIds.contains(track.id))
+        .toList(growable: false);
+
+    final base = switch (_filter) {
+      _DownloadFilter.all => downloaded,
+      _DownloadFilter.notInPlaylist => notInPlaylist,
+      _DownloadFilter.inPlaylist => inPlaylist,
+    };
+    final filtered = _filterDownloadedTracks(base, _query);
+
+    final validIds = downloaded.map((track) => track.id).toSet();
+    _selectedIds.removeWhere((id) => !validIds.contains(id));
 
     return ListView(
       physics: const BouncingScrollPhysics(),
@@ -989,7 +1057,7 @@ class _DownloadsTabState extends ConsumerState<_DownloadsTab> {
           Padding(
             padding: const EdgeInsets.fromLTRB(20, 18, 20, 8),
             child: Text(
-              'Downloaded tracks',
+              'Download manager',
               style: TextStyle(
                 color: AppThemeScope.of(context).onSurface,
                 fontSize: 16,
@@ -997,8 +1065,16 @@ class _DownloadsTabState extends ConsumerState<_DownloadsTab> {
               ),
             ),
           ),
+          _DownloadKpiStrip(
+            downloadedCount: downloaded.length,
+            notInPlaylistCount: notInPlaylist.length,
+            inPlaylistCount: inPlaylist.length,
+            playlistCount: ref.watch(userPlaylistsProvider).length,
+            activeFilter: _filter,
+            onTap: _setFilter,
+          ),
           Padding(
-            padding: const EdgeInsets.fromLTRB(20, 0, 20, 12),
+            padding: const EdgeInsets.fromLTRB(20, 10, 20, 12),
             child: _DownloadsSearchField(
               controller: _searchCtrl,
               onChanged: (value) => setState(() => _query = value),
@@ -1010,11 +1086,33 @@ class _DownloadsTabState extends ConsumerState<_DownloadsTab> {
                     },
             ),
           ),
+          if (_selectionMode)
+            _BulkSelectionBar(
+              selectedCount: _selectedIds.length,
+              visibleCount: filtered.length,
+              onAddToPlaylist: () => _openBulkAddSheet(downloaded),
+              onSelectAll: () => _selectAllVisible(filtered),
+              onClear: _clearSelection,
+            )
+          else
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20, 0, 20, 10),
+              child: Text(
+                'Long press any downloaded song or use the checkboxes to select multiple songs.',
+                style: TextStyle(
+                  color: AppThemeScope.of(context).onSurfaceMuted,
+                  fontSize: 12,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
           if (filtered.isEmpty)
             _EmptyHint(
               icon: PhosphorIconsRegular.magnifyingGlass,
               title: 'No downloaded songs found',
-              subtitle: 'Try title, artist, album, or a close spelling.',
+              subtitle: _filter == _DownloadFilter.notInPlaylist
+                  ? 'Everything downloaded is already inside a playlist.'
+                  : 'Try title, artist, album, or a close spelling.',
             )
           else
             ...List<Widget>.generate(filtered.length, (i) {
@@ -1023,12 +1121,28 @@ class _DownloadsTabState extends ConsumerState<_DownloadsTab> {
                 track: t,
                 queue: filtered,
                 indexInQueue: i,
+                selected: _selectedIds.contains(t.id),
+                selectionMode: _selectionMode,
+                onToggleSelected: () => _toggleSelected(t.id),
+                onEnterSelection: () => _enterSelection(t.id),
               );
             }),
         ],
       ],
     );
   }
+}
+
+Set<int> _downloadPlaylistTrackIds(
+  Map<int, List<DeezerTrack>> tracksByPlaylist,
+) {
+  final ids = <int>{};
+  for (final tracks in tracksByPlaylist.values) {
+    for (final track in tracks) {
+      ids.add(track.id);
+    }
+  }
+  return ids;
 }
 
 List<DeezerTrack> _filterDownloadedTracks(
@@ -1108,6 +1222,224 @@ int _levenshteinDistance(String a, String b) {
   return previous[b.length];
 }
 
+class _DownloadKpiStrip extends StatelessWidget {
+  const _DownloadKpiStrip({
+    required this.downloadedCount,
+    required this.notInPlaylistCount,
+    required this.inPlaylistCount,
+    required this.playlistCount,
+    required this.activeFilter,
+    required this.onTap,
+  });
+
+  final int downloadedCount;
+  final int notInPlaylistCount;
+  final int inPlaylistCount;
+  final int playlistCount;
+  final _DownloadFilter activeFilter;
+  final ValueChanged<_DownloadFilter> onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppThemeScope.of(context);
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 4, 16, 8),
+      child: Wrap(
+        spacing: 10,
+        runSpacing: 10,
+        children: <Widget>[
+          _DownloadKpiCard(
+            label: 'Downloaded',
+            value: downloadedCount,
+            icon: PhosphorIconsFill.cloudCheck,
+            active: activeFilter == _DownloadFilter.all,
+            onTap: () => onTap(_DownloadFilter.all),
+          ),
+          _DownloadKpiCard(
+            label: 'Not in playlist',
+            value: notInPlaylistCount,
+            icon: PhosphorIconsRegular.warningCircle,
+            active: activeFilter == _DownloadFilter.notInPlaylist,
+            onTap: () => onTap(_DownloadFilter.notInPlaylist),
+          ),
+          _DownloadKpiCard(
+            label: 'In playlists',
+            value: inPlaylistCount,
+            icon: PhosphorIconsRegular.playlist,
+            active: activeFilter == _DownloadFilter.inPlaylist,
+            onTap: () => onTap(_DownloadFilter.inPlaylist),
+          ),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+            decoration: BoxDecoration(
+              color: theme.surface,
+              borderRadius: BorderRadius.circular(
+                theme.cardRadius == 0 ? 0 : 16,
+              ),
+              border: Border.all(
+                color: theme.onSurface.withValues(alpha: 0.10),
+              ),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Icon(
+                  PhosphorIconsRegular.listBullets,
+                  color: theme.onSurfaceMuted,
+                  size: 16,
+                ),
+                const SizedBox(width: 8),
+                Text(
+                  '$playlistCount playlists',
+                  style: TextStyle(
+                    color: theme.onSurfaceMuted,
+                    fontSize: 12,
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DownloadKpiCard extends StatelessWidget {
+  const _DownloadKpiCard({
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.active,
+    required this.onTap,
+  });
+
+  final String label;
+  final int value;
+  final IconData icon;
+  final bool active;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppThemeScope.of(context);
+    final border = active ? theme.accent : theme.onSurface.withValues(alpha: 0.10);
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: onTap,
+      child: AnimatedContainer(
+        duration: theme.fastDuration,
+        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+        decoration: BoxDecoration(
+          color: active
+              ? theme.accent.withValues(alpha: 0.12)
+              : theme.surface,
+          borderRadius: BorderRadius.circular(
+            theme.cardRadius == 0 ? 0 : 16,
+          ),
+          border: Border.all(color: border),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(
+              icon,
+              color: active ? theme.accent : theme.onSurfaceMuted,
+              size: 16,
+            ),
+            const SizedBox(width: 8),
+            Text(
+              '$value',
+              style: TextStyle(
+                color: active ? theme.accent : theme.onSurface,
+                fontSize: 16,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+            const SizedBox(width: 6),
+            Text(
+              label,
+              style: TextStyle(
+                color: active ? theme.onSurface : theme.onSurfaceMuted,
+                fontSize: 12,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BulkSelectionBar extends StatelessWidget {
+  const _BulkSelectionBar({
+    required this.selectedCount,
+    required this.visibleCount,
+    required this.onAddToPlaylist,
+    required this.onSelectAll,
+    required this.onClear,
+  });
+
+  final int selectedCount;
+  final int visibleCount;
+  final VoidCallback onAddToPlaylist;
+  final VoidCallback onSelectAll;
+  final VoidCallback onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = AppThemeScope.of(context);
+
+    return Container(
+      margin: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: theme.accent.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(theme.cardRadius == 0 ? 0 : 16),
+        border: Border.all(color: theme.accent.withValues(alpha: 0.55)),
+      ),
+      child: Wrap(
+        spacing: 8,
+        runSpacing: 8,
+        crossAxisAlignment: WrapCrossAlignment.center,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+            child: Text(
+              '$selectedCount selected',
+              style: TextStyle(
+                color: theme.onSurface,
+                fontSize: 13,
+                fontWeight: FontWeight.w900,
+              ),
+            ),
+          ),
+          _SmallActionButton(
+            label: 'Add to playlist',
+            icon: PhosphorIconsRegular.playlist,
+            onTap: onAddToPlaylist,
+            filled: true,
+          ),
+          _SmallActionButton(
+            label: 'Select visible ($visibleCount)',
+            icon: PhosphorIconsRegular.checks,
+            onTap: onSelectAll,
+          ),
+          _SmallActionButton(
+            label: 'Clear',
+            icon: PhosphorIconsRegular.x,
+            onTap: onClear,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
 class _DownloadsSearchField extends StatelessWidget {
   const _DownloadsSearchField({
     required this.controller,
@@ -1184,38 +1516,139 @@ class _DownloadedTrackTile extends ConsumerWidget {
     required this.track,
     required this.queue,
     required this.indexInQueue,
+    required this.selected,
+    required this.selectionMode,
+    required this.onToggleSelected,
+    required this.onEnterSelection,
   });
 
   final DeezerTrack track;
   final List<DeezerTrack> queue;
   final int indexInQueue;
+  final bool selected;
+  final bool selectionMode;
+  final VoidCallback onToggleSelected;
+  final VoidCallback onEnterSelection;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = AppThemeScope.of(context);
     final playlists = ref.watch(playlistsForTrackProvider(track.id));
     final inPlaylist = playlists.isNotEmpty;
+    final cover = track.album?.coverMedium ??
+        track.album?.cover ??
+        track.album?.coverSmall;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: <Widget>[
-        Stack(
-          children: <Widget>[
-            TrackRow(track: track, queue: queue, indexInQueue: indexInQueue),
-            Positioned(
-              top: 8,
-              right: 12,
-              child: Icon(
-                PhosphorIconsFill.cloudCheck,
-                color: theme.accent,
-                size: 14,
+        GestureDetector(
+          behavior: HitTestBehavior.opaque,
+          onTap: selectionMode
+              ? onToggleSelected
+              : () => ref
+                  .read(playerControlsProvider)
+                  .playTracks(queue, startIndex: indexInQueue),
+          onLongPress: onEnterSelection,
+          child: Container(
+            margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+            decoration: BoxDecoration(
+              color: selected
+                  ? theme.accent.withValues(alpha: 0.12)
+                  : Colors.transparent,
+              borderRadius: BorderRadius.circular(
+                theme.cardRadius == 0 ? 0 : 14,
+              ),
+              border: Border.all(
+                color: selected
+                    ? theme.accent.withValues(alpha: 0.65)
+                    : Colors.transparent,
               ),
             ),
-          ],
+            child: Row(
+              children: <Widget>[
+                Checkbox(
+                  value: selected,
+                  onChanged: (_) => onToggleSelected(),
+                  visualDensity: VisualDensity.compact,
+                ),
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(
+                    theme.cardRadius == 0 ? 0 : 8,
+                  ),
+                  child: SizedBox(
+                    width: 48,
+                    height: 48,
+                    child: cover != null
+                        ? CachedNetworkImage(
+                            imageUrl: cover,
+                            fit: BoxFit.cover,
+                            placeholder: (_, _) =>
+                                ColoredBox(color: theme.surface),
+                            errorWidget: (_, _, _) =>
+                                ColoredBox(color: theme.surface),
+                          )
+                        : ColoredBox(
+                            color: theme.surface,
+                            child: Icon(
+                              PhosphorIconsRegular.musicNotes,
+                              color: theme.onSurfaceMuted,
+                            ),
+                          ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        track.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: theme.onSurface,
+                          fontSize: 14,
+                          fontWeight: FontWeight.w800,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        track.artist?.name ?? 'Unknown artist',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: TextStyle(
+                          color: theme.onSurfaceMuted,
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 8),
+                if (!selectionMode)
+                  Icon(
+                    PhosphorIconsFill.cloudCheck,
+                    color: theme.accent,
+                    size: 16,
+                  )
+                else
+                  Icon(
+                    selected
+                        ? PhosphorIconsFill.checkCircle
+                        : PhosphorIconsRegular.circle,
+                    color: selected ? theme.accent : theme.onSurfaceMuted,
+                    size: 20,
+                  ),
+              ],
+            ),
+          ),
         ),
         if (inPlaylist)
           Padding(
-            padding: const EdgeInsets.fromLTRB(72, 0, 16, 6),
+            padding: const EdgeInsets.fromLTRB(88, 0, 16, 6),
             child: Text(
               'In playlist: ${_playlistPreview(playlists)}',
               maxLines: 1,
@@ -1226,19 +1659,32 @@ class _DownloadedTrackTile extends ConsumerWidget {
                 fontWeight: FontWeight.w800,
               ),
             ),
-          ),
-        Padding(
-          padding: const EdgeInsets.fromLTRB(72, 0, 16, 10),
-          child: Align(
-            alignment: Alignment.centerRight,
-            child: _SmallActionButton(
-              label: inPlaylist ? 'Manage playlists' : 'Add to playlist',
-              icon: PhosphorIconsRegular.playlist,
-              onTap: () => showAddToPlaylistSheet(context, track),
-              filled: true,
+          )
+        else
+          Padding(
+            padding: const EdgeInsets.fromLTRB(88, 0, 16, 6),
+            child: Text(
+              'Not in any playlist',
+              style: TextStyle(
+                color: theme.onSurfaceMuted,
+                fontSize: 11,
+                fontWeight: FontWeight.w700,
+              ),
             ),
           ),
-        ),
+        if (!selectionMode)
+          Padding(
+            padding: const EdgeInsets.fromLTRB(88, 0, 16, 10),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: _SmallActionButton(
+                label: inPlaylist ? 'Manage playlists' : 'Add to playlist',
+                icon: PhosphorIconsRegular.playlist,
+                onTap: () => showAddToPlaylistSheet(context, track),
+                filled: true,
+              ),
+            ),
+          ),
       ],
     );
   }
@@ -1422,13 +1868,117 @@ class _DownloadQueueCard extends ConsumerWidget {
   }
 }
 
-class _DownloadLocationCard extends ConsumerWidget {
+class _DownloadLocationCard extends ConsumerStatefulWidget {
   const _DownloadLocationCard();
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<_DownloadLocationCard> createState() =>
+      _DownloadLocationCardState();
+}
+
+class _DownloadLocationCardState extends ConsumerState<_DownloadLocationCard> {
+  bool _exporting = false;
+
+  Future<void> _exportBackup() async {
+    if (_exporting) return;
+
+    setState(() => _exporting = true);
+
+    try {
+      final result = await ref
+          .read(downloadManagerProvider)
+          .exportDownloadsBackup();
+
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Downloads exported: ${result.filesCopied} files · '
+            '${_formatBytes(result.bytesCopied)} → '
+            'Internal storage/Download/WAVE/wave_downloads',
+          ),
+        ),
+      );
+    } catch (e) {
+      if (!mounted) return;
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            'Could not export to Internal storage/Download/WAVE/wave_downloads. '
+            'Android may have blocked public Download folder access on this device. $e',
+          ),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _exporting = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final theme = AppThemeScope.of(context);
-    final locationAsync = ref.watch(downloadLocationProvider);
+
+    if (!Platform.isAndroid) {
+      final locationAsync = ref.watch(downloadLocationProvider);
+
+      return Container(
+        margin: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+        padding: const EdgeInsets.all(14),
+        decoration: BoxDecoration(
+          color: theme.background,
+          borderRadius: BorderRadius.circular(theme.cardRadius == 0 ? 0 : 14),
+          border: Border.all(color: theme.onSurface.withValues(alpha: 0.10)),
+        ),
+        child: locationAsync.when(
+          loading: () => Text(
+            'Finding download folder...',
+            style: TextStyle(color: theme.onSurfaceMuted, fontSize: 12),
+          ),
+          error: (_, _) => Text(
+            'Could not show download folder',
+            style: TextStyle(color: theme.onSurfaceMuted, fontSize: 12),
+          ),
+          data: (path) => Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                'Download folder',
+                style: TextStyle(
+                  color: theme.onSurface,
+                  fontSize: 13,
+                  fontWeight: FontWeight.w900,
+                ),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                path,
+                style: TextStyle(color: theme.onSurfaceMuted, fontSize: 11),
+              ),
+              const SizedBox(height: 10),
+              _SmallActionButton(
+                label: 'Open folder',
+                icon: PhosphorIconsRegular.folderOpen,
+                onTap: () async {
+                  try {
+                    await ref.read(downloadManagerProvider).openDownloadsFolder();
+                  } catch (e) {
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text(e.toString())),
+                      );
+                    }
+                  }
+                },
+              ),
+            ],
+          ),
+        ),
+      );
+    }
 
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 8, 16, 4),
@@ -1438,70 +1988,67 @@ class _DownloadLocationCard extends ConsumerWidget {
         borderRadius: BorderRadius.circular(theme.cardRadius == 0 ? 0 : 14),
         border: Border.all(color: theme.onSurface.withValues(alpha: 0.10)),
       ),
-      child: locationAsync.when(
-        loading: () => Text(
-          'Finding download folder...',
-          style: TextStyle(color: theme.onSurfaceMuted, fontSize: 12),
-        ),
-        error: (_, _) => Text(
-          'Could not show download folder',
-          style: TextStyle(color: theme.onSurfaceMuted, fontSize: 12),
-        ),
-        data: (path) => Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(
-              'Download folder',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Downloads backup',
+            style: TextStyle(
+              color: theme.onSurface,
+              fontSize: 13,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'WAVE keeps songs in private app storage so offline playback works.',
+            style: TextStyle(
+              color: theme.onSurfaceMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Export backup copies them to:',
+            style: TextStyle(
+              color: theme.onSurfaceMuted,
+              fontSize: 11,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          const SizedBox(height: 4),
+          Text(
+            'Internal storage/Download/WAVE/wave_downloads',
+            style: TextStyle(
+              color: theme.onSurface,
+              fontSize: 12,
+              fontWeight: FontWeight.w900,
+            ),
+          ),
+          const SizedBox(height: 10),
+          _SmallActionButton(
+            label: _exporting ? 'Exporting...' : 'Export backup',
+            icon: PhosphorIconsRegular.export,
+            onTap: _exporting ? () {} : _exportBackup,
+            filled: true,
+          ),
+          Padding(
+            padding: const EdgeInsets.only(top: 8),
+            child: Text(
+              'This is a copy/backup. WAVE will still play from its private folder.',
               style: TextStyle(
-                color: theme.onSurface,
-                fontSize: 13,
-                fontWeight: FontWeight.w900,
+                color: theme.onSurfaceMuted,
+                fontSize: 10.5,
+                fontWeight: FontWeight.w600,
               ),
             ),
-            const SizedBox(height: 6),
-            Text(
-              path,
-              style: TextStyle(color: theme.onSurfaceMuted, fontSize: 11),
-            ),
-            if (Platform.isWindows || Platform.isMacOS || Platform.isLinux)
-              Padding(
-                padding: const EdgeInsets.only(top: 10),
-                child: _SmallActionButton(
-                  label: 'Open folder',
-                  icon: PhosphorIconsRegular.export,
-                  onTap: () async {
-                    try {
-                      await ref.read(downloadManagerProvider).openDownloadsFolder();
-                    } catch (e) {
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text(e.toString())),
-                        );
-                      }
-                    }
-                  },
-                  filled: true,
-                ),
-              )
-            else
-              Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  'Android stores these in WAVE app-private storage.',
-                  style: TextStyle(
-                    color: theme.onSurfaceMuted,
-                    fontSize: 11,
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }
 }
-
 
 String _currentDownloadDetail(DownloadQueueItem item) {
   final percent = (item.progress.clamp(0.0, 1.0) * 100).floor();

--- a/lib/features/player/now_playing_screen.dart
+++ b/lib/features/player/now_playing_screen.dart
@@ -25,6 +25,7 @@ import '../../widgets/player/sleep_timer_dial.dart';
 import '../../widgets/player/waveform_bars.dart';
 import '../../core/downloads/download_manager.dart';
 import '../../core/downloads/download_providers.dart';
+import '../../core/downloads/download_status.dart';
 
 /// Now-Playing screen. Branches on `theme.id` to render six distinct
 /// presentations of the same player state.
@@ -737,7 +738,7 @@ class _DownloadButton extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = AppThemeScope.of(context);
     final downloadedTracks = ref.watch(downloadedTracksProvider);
-    final isDownloaded = downloadedTracks.any((t) => t.id == track.id);
+    final isDownloaded = isTrackOnDevice(track, downloadedTracks);
     
     final activeDownloads = ref.watch(activeDownloadsProvider);
     final progress = activeDownloads[track.id];
@@ -761,10 +762,14 @@ class _DownloadButton extends ConsumerWidget {
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: () {
+        final manager = ref.read(downloadManagerProvider);
         if (isDownloaded) {
-          ref.read(downloadManagerProvider).deleteDownload(track.id);
+          manager.deleteDownload(track.id);
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Removed from device: ${track.title}')),
+          );
         } else {
-          ref.read(downloadManagerProvider).downloadTrack(track);
+          manager.downloadTrack(track);
         }
       },
       child: Padding(

--- a/lib/features/playlist/playlist_screen.dart
+++ b/lib/features/playlist/playlist_screen.dart
@@ -12,6 +12,7 @@ import '../../core/api/models/deezer_track.dart';
 import '../../core/audio/player_providers.dart';
 import '../../core/downloads/download_manager.dart';
 import '../../core/downloads/download_providers.dart';
+import '../../core/downloads/download_status.dart';
 import '../../core/storage/library_providers.dart';
 import '../../core/utils/playlist_exchange.dart';
 import '../../core/theme/app_theme.dart';
@@ -901,16 +902,39 @@ class _DownloadPlaylistButton extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = AppThemeScope.of(context);
-    final enabled = tracks.isNotEmpty;
+    final coverage = downloadCoverageForTracks(
+      tracks,
+      ref.watch(downloadedTracksProvider),
+    );
+    final enabled = coverage.hasTracks;
+    final allOnDevice = coverage.allOnDevice;
 
     return GestureDetector(
       behavior: HitTestBehavior.opaque,
       onTap: !enabled
           ? null
           : () {
-              ref.read(downloadManagerProvider).downloadPlaylist(title, tracks);
+              if (allOnDevice) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(content: Text('Playlist is already on device: $title')),
+                );
+                return;
+              }
+              ref.read(downloadManagerProvider).queueTracks(
+                    coverage.missingTracks,
+                    title: coverage.partiallyOnDevice
+                        ? 'Missing playlist tracks: $title'
+                        : 'Playlist: $title',
+                    replaceFinishedQueue: false,
+                  );
               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Queued playlist download: $title')),
+                SnackBar(
+                  content: Text(
+                    coverage.partiallyOnDevice
+                        ? 'Queued ${coverage.missing} missing playlist tracks: $title'
+                        : 'Queued playlist download: $title',
+                  ),
+                ),
               );
             },
       child: AnimatedOpacity(
@@ -925,22 +949,30 @@ class _DownloadPlaylistButton extends ConsumerWidget {
               theme.cardRadius == 0 ? 0 : 999,
             ),
             border: Border.all(
-              color: theme.onSurface.withValues(alpha: 0.12),
+              color: allOnDevice
+                  ? theme.accent.withValues(alpha: 0.55)
+                  : theme.onSurface.withValues(alpha: 0.12),
             ),
           ),
           child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
               Icon(
-                PhosphorIconsRegular.cloudArrowDown,
-                color: theme.onSurface,
+                allOnDevice
+                    ? PhosphorIconsFill.cloudCheck
+                    : PhosphorIconsRegular.cloudArrowDown,
+                color: allOnDevice ? theme.accent : theme.onSurface,
                 size: 16,
               ),
               const SizedBox(width: 8),
               Text(
-                'Download playlist',
+                allOnDevice
+                    ? 'Playlist on device'
+                    : (coverage.partiallyOnDevice
+                        ? 'Download missing (${coverage.missing})'
+                        : 'Download playlist'),
                 style: TextStyle(
-                  color: theme.onSurface,
+                  color: allOnDevice ? theme.accent : theme.onSurface,
                   fontSize: 13,
                   fontWeight: FontWeight.w900,
                   letterSpacing: 0.3,

--- a/lib/widgets/content_cards.dart
+++ b/lib/widgets/content_cards.dart
@@ -10,10 +10,11 @@ import '../core/api/models/deezer_playlist.dart';
 import '../core/api/models/deezer_track.dart';
 import '../core/audio/player_providers.dart';
 import '../core/downloads/download_providers.dart';
-import '../core/downloads/local_download_matcher.dart';
+import '../core/downloads/download_status.dart';
 import '../core/router/app_router.dart';
 import '../core/storage/recently_played.dart';
 import '../core/theme/app_theme.dart';
+import 'on_device_badge.dart';
 
 /// Album-cover sized card with title + subtitle, used by Made-for-you,
 /// New releases, Mixes, Editorial, etc.
@@ -237,11 +238,10 @@ class TrackRow extends ConsumerWidget {
     final cover = track.album?.coverMedium ??
         track.album?.cover ??
         track.album?.coverSmall;
-    final downloadedMatch = LocalDownloadMatcher.findDownloadedMatchInList(
+    final onDevice = isTrackOnDevice(
       track,
       ref.watch(downloadedTracksProvider),
     );
-    final onDevice = downloadedMatch != null;
     final placeholder = Container(
       width: 48,
       height: 48,
@@ -328,7 +328,7 @@ class TrackRow extends ConsumerWidget {
                   if (onDevice)
                     Padding(
                       padding: const EdgeInsets.only(top: 4),
-                      child: _OnDeviceBadge(theme: theme),
+                      child: OnDeviceBadge(theme: theme),
                     ),
                 ],
               ),
@@ -349,44 +349,6 @@ class TrackRow extends ConsumerWidget {
   }
 }
 
-
-class _OnDeviceBadge extends StatelessWidget {
-  const _OnDeviceBadge({required this.theme});
-
-  final AppTheme theme;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 7, vertical: 3),
-      decoration: BoxDecoration(
-        color: theme.accent.withValues(alpha: 0.12),
-        borderRadius: BorderRadius.circular(999),
-        border: Border.all(color: theme.accent.withValues(alpha: 0.45)),
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: <Widget>[
-          Icon(
-            PhosphorIconsFill.cloudCheck,
-            color: theme.accent,
-            size: 11,
-          ),
-          const SizedBox(width: 4),
-          Text(
-            'On device',
-            style: TextStyle(
-              color: theme.accent,
-              fontSize: 10,
-              fontWeight: FontWeight.w900,
-              letterSpacing: 0.2,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-}
 
 String _fmtDuration(int? secs) {
   if (secs == null || secs <= 0) return '--:--';
@@ -410,12 +372,28 @@ class TrackCard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final theme = AppThemeScope.of(context);
     final cover = track.album?.coverBig ?? track.album?.coverMedium ?? track.album?.cover;
+    final onDevice = isTrackOnDevice(
+      track,
+      ref.watch(downloadedTracksProvider),
+    );
     return CoverCard(
       imageUrl: cover,
       title: track.title,
-      subtitle: track.artist?.name ?? 'Track',
+      subtitle: onDevice
+          ? '${track.artist?.name ?? 'Track'} · On device'
+          : (track.artist?.name ?? 'Track'),
       size: size,
+      overlay: onDevice
+          ? Align(
+              alignment: Alignment.bottomLeft,
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: OnDeviceBadge(theme: theme, compact: true),
+              ),
+            )
+          : null,
       onTap: () async {
         final controls = ref.read(playerControlsProvider);
         final indexInQueue = queue.indexOf(track);

--- a/lib/widgets/detail_track_row.dart
+++ b/lib/widgets/detail_track_row.dart
@@ -7,9 +7,10 @@ import '../core/api/models/deezer_track.dart';
 import '../core/audio/player_providers.dart';
 import '../core/downloads/download_manager.dart';
 import '../core/downloads/download_providers.dart';
-import '../core/downloads/local_download_matcher.dart';
+import '../core/downloads/download_status.dart';
 import '../core/storage/library_providers.dart';
 import '../core/theme/app_theme.dart';
+import 'on_device_badge.dart';
 import 'context_menu.dart';
 
 /// Tracklist row used by Album / Playlist pages. Shows numbered position,
@@ -39,10 +40,10 @@ class DetailTrackRow extends ConsumerWidget {
     final liked = ref
         .watch(likedTracksProvider)
         .any((t) => t.id == track.id);
-    // For the manual "Download track" action, use exact Deezer ID only.
-    // Fuzzy matching is still used by playback/local-first, but it must not
-    // block downloading a specific version the user tapped.
-    final downloaded = LocalDownloadMatcher.isDownloadedById(track.id);
+    final downloaded = isTrackOnDevice(
+      track,
+      ref.watch(downloadedTracksProvider),
+    );
     final downloading = ref.watch(activeDownloadsProvider).containsKey(track.id);
     final cover = track.album?.coverSmall ?? track.album?.cover;
     return GestureDetector(
@@ -121,6 +122,11 @@ class DetailTrackRow extends ConsumerWidget {
                           fontSize: 12,
                         ),
                       ),
+                    ),
+                  if (downloaded)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: OnDeviceBadge(theme: theme),
                     ),
                 ],
               ),

--- a/lib/widgets/on_device_badge.dart
+++ b/lib/widgets/on_device_badge.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:phosphoricons_flutter/phosphoricons_flutter.dart';
+
+import '../core/theme/app_theme.dart';
+
+class OnDeviceBadge extends StatelessWidget {
+  const OnDeviceBadge({
+    super.key,
+    required this.theme,
+    this.compact = false,
+  });
+
+  final AppTheme theme;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.symmetric(
+        horizontal: compact ? 6 : 7,
+        vertical: compact ? 2.5 : 3,
+      ),
+      decoration: BoxDecoration(
+        color: theme.accent.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(color: theme.accent.withValues(alpha: 0.45)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(
+            PhosphorIconsFill.cloudCheck,
+            color: theme.accent,
+            size: compact ? 10 : 11,
+          ),
+          const SizedBox(width: 4),
+          Text(
+            'On device',
+            style: TextStyle(
+              color: theme.accent,
+              fontSize: compact ? 9.5 : 10,
+              fontWeight: FontWeight.w900,
+              letterSpacing: 0.2,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/player/add_to_playlist_sheet.dart
+++ b/lib/widgets/player/add_to_playlist_sheet.dart
@@ -9,18 +9,27 @@ import '../../core/storage/library_providers.dart';
 import '../../core/theme/app_theme.dart';
 
 void showAddToPlaylistSheet(BuildContext context, DeezerTrack track) {
+  showAddTracksToPlaylistSheet(context, <DeezerTrack>[track]);
+}
+
+void showAddTracksToPlaylistSheet(
+  BuildContext context,
+  List<DeezerTrack> tracks,
+) {
+  if (tracks.isEmpty) return;
+
   showModalBottomSheet<void>(
     context: context,
     isScrollControlled: true,
     backgroundColor: Colors.transparent,
-    builder: (ctx) => _AddToPlaylistSheet(track: track),
+    builder: (ctx) => _AddToPlaylistSheet(tracks: tracks),
   );
 }
 
 class _AddToPlaylistSheet extends ConsumerStatefulWidget {
-  const _AddToPlaylistSheet({required this.track});
+  const _AddToPlaylistSheet({required this.tracks});
 
-  final DeezerTrack track;
+  final List<DeezerTrack> tracks;
 
   @override
   ConsumerState<_AddToPlaylistSheet> createState() => _AddToPlaylistSheetState();
@@ -29,6 +38,9 @@ class _AddToPlaylistSheet extends ConsumerStatefulWidget {
 class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
   final _controller = TextEditingController();
   bool _creating = false;
+
+  bool get _single => widget.tracks.length == 1;
+  DeezerTrack get _firstTrack => widget.tracks.first;
 
   @override
   void dispose() {
@@ -42,12 +54,12 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
 
     final playlist = await ref.read(userPlaylistsProvider.notifier).create(
           title: title,
-          coverUrl: widget.track.album?.coverBig ?? widget.track.album?.cover,
+          coverUrl: _firstTrack.album?.coverBig ?? _firstTrack.album?.cover,
         );
 
     await ref
         .read(localPlaylistTracksProvider.notifier)
-        .addTrack(playlist.id, widget.track);
+        .addTracks(playlist.id, widget.tracks);
 
     if (!mounted) return;
     setState(() {
@@ -56,25 +68,33 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
     });
 
     ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text('Added to "${playlist.title}"')),
+      SnackBar(content: Text(_addedMessage(playlist.title, widget.tracks.length))),
     );
   }
 
-  Future<void> _togglePlaylist(DeezerPlaylist playlist, bool alreadyIn) async {
+  Future<void> _togglePlaylist(
+    DeezerPlaylist playlist, {
+    required int alreadyCount,
+  }) async {
     final notifier = ref.read(localPlaylistTracksProvider.notifier);
-    if (alreadyIn) {
-      await notifier.removeTrack(playlist.id, widget.track.id);
+    final allInPlaylist = alreadyCount == widget.tracks.length;
+
+    if (allInPlaylist) {
+      await notifier.removeTracks(
+        playlist.id,
+        widget.tracks.map((track) => track.id),
+      );
     } else {
-      await notifier.addTrack(playlist.id, widget.track);
+      await notifier.addTracks(playlist.id, widget.tracks);
     }
 
     if (!mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(
-          alreadyIn
-              ? 'Removed from "${playlist.title}"'
-              : 'Added to "${playlist.title}"',
+          allInPlaylist
+              ? _removedMessage(playlist.title, widget.tracks.length)
+              : _addedMessage(playlist.title, widget.tracks.length - alreadyCount),
         ),
       ),
     );
@@ -85,7 +105,15 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
     final theme = AppThemeScope.of(context);
     final playlists = ref.watch(userPlaylistsProvider);
     final tracksByPlaylist = ref.watch(localPlaylistTracksProvider);
-    final alreadyIn = ref.watch(playlistsForTrackProvider(widget.track.id));
+    final selectedIds = widget.tracks.map((track) => track.id).toSet();
+
+    final alreadyIn = _single
+        ? ref.watch(playlistsForTrackProvider(_firstTrack.id))
+        : playlists.where((playlist) {
+            final tracks =
+                tracksByPlaylist[playlist.id] ?? const <DeezerTrack>[];
+            return tracks.any((track) => selectedIds.contains(track.id));
+          }).toList(growable: false);
 
     return DraggableScrollableSheet(
       initialChildSize: 0.68,
@@ -110,7 +138,7 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
               ),
               const SizedBox(height: 16),
               Text(
-                'Manage playlists',
+                _single ? 'Manage playlists' : 'Add selected to playlist',
                 style: TextStyle(
                   color: theme.onSurface,
                   fontSize: 18,
@@ -121,9 +149,7 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 20),
                 child: Text(
-                  alreadyIn.isEmpty
-                      ? 'This downloaded song is not in any playlist yet.'
-                      : 'Already in: ${_playlistNames(alreadyIn)}',
+                  _subtitle(alreadyIn),
                   textAlign: TextAlign.center,
                   style: TextStyle(
                     color: theme.onSurfaceMuted,
@@ -193,7 +219,9 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
                     ),
                   ),
                   subtitle: Text(
-                    'Creates it and adds this song',
+                    _single
+                        ? 'Creates it and adds this song'
+                        : 'Creates it and adds ${widget.tracks.length} selected songs',
                     style: TextStyle(
                       color: theme.onSurfaceMuted,
                       fontSize: 12,
@@ -220,8 +248,11 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
                           final playlist = playlists[i];
                           final tracks = tracksByPlaylist[playlist.id] ??
                               const <DeezerTrack>[];
-                          final isInPlaylist =
-                              tracks.any((t) => t.id == widget.track.id);
+                          final alreadyCount = tracks
+                              .where((track) => selectedIds.contains(track.id))
+                              .length;
+                          final allInPlaylist =
+                              alreadyCount == widget.tracks.length;
                           final cover = playlist.pictureBig ??
                               playlist.pictureMedium ??
                               playlist.picture;
@@ -256,27 +287,32 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
                               ),
                             ),
                             subtitle: Text(
-                              isInPlaylist
-                                  ? 'In this playlist · tap to remove'
-                                  : '${playlist.nbTracks ?? tracks.length} tracks · tap to add',
+                              _playlistSubtitle(
+                                playlist: playlist,
+                                playlistTrackCount: tracks.length,
+                                alreadyCount: alreadyCount,
+                              ),
                               style: TextStyle(
-                                color: isInPlaylist
+                                color: allInPlaylist
                                     ? theme.accent
                                     : theme.onSurfaceMuted,
                                 fontSize: 12,
-                                fontWeight: isInPlaylist
+                                fontWeight: allInPlaylist
                                     ? FontWeight.w700
                                     : FontWeight.w500,
                               ),
                             ),
                             trailing: _PlaylistTogglePill(
-                              label: isInPlaylist ? 'Remove' : 'Add',
-                              icon: isInPlaylist
+                              label: allInPlaylist ? 'Remove' : 'Add',
+                              icon: allInPlaylist
                                   ? PhosphorIconsRegular.minusCircle
                                   : PhosphorIconsRegular.plusCircle,
-                              accent: isInPlaylist ? theme.error : theme.accent,
+                              accent: allInPlaylist ? theme.error : theme.accent,
                             ),
-                            onTap: () => _togglePlaylist(playlist, isInPlaylist),
+                            onTap: () => _togglePlaylist(
+                              playlist,
+                              alreadyCount: alreadyCount,
+                            ),
                           );
                         },
                       ),
@@ -287,6 +323,63 @@ class _AddToPlaylistSheetState extends ConsumerState<_AddToPlaylistSheet> {
       },
     );
   }
+
+  String _subtitle(List<DeezerPlaylist> alreadyIn) {
+    if (_single) {
+      if (alreadyIn.isEmpty) {
+        return 'This downloaded song is not in any playlist yet.';
+      }
+      return 'Already in: ${_playlistNames(alreadyIn)}';
+    }
+
+    if (alreadyIn.isEmpty) {
+      return '${widget.tracks.length} selected downloaded songs are not in any playlist yet.';
+    }
+
+    return '${widget.tracks.length} selected songs · already found in ${alreadyIn.length} playlist${alreadyIn.length == 1 ? '' : 's'}.';
+  }
+
+  String _playlistSubtitle({
+    required DeezerPlaylist playlist,
+    required int playlistTrackCount,
+    required int alreadyCount,
+  }) {
+    if (_single) {
+      return alreadyCount > 0
+          ? 'In this playlist · tap to remove'
+          : '${playlist.nbTracks ?? playlistTrackCount} tracks · tap to add';
+    }
+
+    if (alreadyCount == widget.tracks.length) {
+      return 'All ${widget.tracks.length} selected are in this playlist · tap to remove';
+    }
+
+    if (alreadyCount > 0) {
+      final missing = widget.tracks.length - alreadyCount;
+      return '$alreadyCount already here · tap to add $missing missing';
+    }
+
+    return '${playlist.nbTracks ?? playlistTrackCount} tracks · tap to add selected';
+  }
+}
+
+String _playlistNames(List<DeezerPlaylist> playlists) {
+  if (playlists.length <= 2) {
+    return playlists.map((p) => p.title).join(', ');
+  }
+  return '${playlists.take(2).map((p) => p.title).join(', ')} +${playlists.length - 2}';
+}
+
+String _addedMessage(String playlistTitle, int count) {
+  return count == 1
+      ? 'Added to "$playlistTitle"'
+      : 'Added $count songs to "$playlistTitle"';
+}
+
+String _removedMessage(String playlistTitle, int count) {
+  return count == 1
+      ? 'Removed from "$playlistTitle"'
+      : 'Removed $count songs from "$playlistTitle"';
 }
 
 class _PlaylistTogglePill extends StatelessWidget {
@@ -326,12 +419,4 @@ class _PlaylistTogglePill extends StatelessWidget {
       ),
     );
   }
-}
-
-String _playlistNames(List<DeezerPlaylist> playlists) {
-  if (playlists.length <= 3) {
-    return playlists.map((p) => p.title).join(', ');
-  }
-  final first = playlists.take(3).map((p) => p.title).join(', ');
-  return '$first +${playlists.length - 3} more';
 }


### PR DESCRIPTION
## Summary

This PR improves WAVE’s local download and playlist management workflow.

It adds a proper download manager experience, bulk playlist actions, global “On device” status, and an Android-friendly song export backup option.

## What changed

### Download / Playlist Manager

Added KPI cards in `Library > Downloads`:

* Downloaded
* Not in playlist
* In playlists
* Playlists

These cards also work as filters, so users can quickly find downloaded songs that are not yet organised into playlists.

### Multi-select downloads

Users can now select multiple downloaded tracks using long press or checkboxes.

Bulk actions include:

* Add selected songs to an existing playlist
* Create a new playlist from selected songs
* Select visible songs
* Clear selection

### Playlist management

Improved playlist management so users can:

* Add downloaded songs into a playlist
* Remove songs from a playlist
* Manage songs from inside the playlist screen
* Keep downloaded songs separate from playlist membership

### Global “On device” status

Downloaded songs now show an `On device` status more consistently across the app, including:

* Search results
* Home/content cards
* Album track lists
* Artist popular tracks
* Playlist track lists
* Now Playing
* Track detail rows

### Smarter download behaviour

The app now avoids downloading the same song again when it is already on the device.

For albums, playlists, and artist popular tracks:

* If everything is already downloaded, the app shows that it is already on device
* If only some songs are missing, only the missing songs are queued

### Restore cloud-check delete behaviour

The cloud button keeps the existing expected behaviour:

* Cloud download icon = download song
* Cloud check icon = remove/delete song from device

### Android song export backup

On Android, WAVE stores downloaded songs in private app storage for reliable offline playback.

Instead of showing the internal `/data/user/...` path to the user, the app now explains that songs are stored privately and provides an export option.

Export backup copies songs to:

```text
Internal storage/Download/WAVE/wave_downloads
```

The export is a backup/copy only. WAVE still plays from its private folder.

### Song-only export

The export backup now copies only actual song/audio files.

It skips:

* Cover artwork
* `_cover` files
* `.jpg`
* `.jpeg`
* `.png`
* `.webp`
* `.gif`
* `wave_downloads_manifest.json`

### Desktop behaviour

Windows/macOS/Linux still show the normal local download folder and allow the user to open it.

The Android export message only appears on Android.

## Testing

Tested locally:

* Opened Library > Downloads
* Verified KPI cards display correctly
* Filtered downloaded tracks
* Filtered tracks not in playlists
* Selected multiple downloaded songs
* Added selected songs to an existing playlist
* Created a new playlist from selected songs
* Removed songs from playlists
* Verified `On device` appears across multiple screens
* Verified already-downloaded tracks are not downloaded again
* Verified cloud-check removes the song from device
* Verified export backup copies songs only
* Verified desktop still shows the normal download folder
